### PR TITLE
initial functional tests - refractor argument parsing in class

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = wtfuzz
+omit =
+    tests/*
+    */__init__.py
+
+[report]
+exclude_lines =
+    if __name__ == '__main__':

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 mattjegan
 dbradf
+shepherdjay

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 crayons==0.1.2
 requests==2.13.0
+pytest
+responses
+pytest-cov

--- a/tests/test_mylist.txt
+++ b/tests/test_mylist.txt
@@ -1,0 +1,2 @@
+index.html
+home/careers.html

--- a/tests/test_wtfuzz.py
+++ b/tests/test_wtfuzz.py
@@ -1,0 +1,69 @@
+import os
+
+import responses
+
+import wtfuzz.wtfuzz as wtfuzz
+
+
+def get_path(file):
+    path = os.path.join(os.path.dirname(__file__), file)
+    return path
+
+
+def setup_module(module):
+    # Setup our good urls
+    responses.add(responses.GET, 'http://www.good-example.com/index.html',
+                  body='okay',
+                  content_type='application/json',
+                  status=200,
+                  )
+    responses.add(responses.GET, 'http://www.good-example.com/home/careers.html',
+                  body='okay',
+                  content_type='application/json',
+                  status=200,
+                  )
+
+    # Setup our bad urls
+    responses.add(responses.GET, 'http://www.bad-example.com/index.html',
+                  body='okay',
+                  content_type='application/json',
+                  status=200,
+                  )
+    responses.add(responses.GET, 'http://www.bad-example.com/home/careers.html',
+                  body='oops',
+                  content_type='application/json',
+                  status=404,
+                  )
+
+
+@responses.activate
+def test_functional_simple_no_optional_args(capsys):
+    """
+    Simple functional test to ensure core function
+    :return:
+    """
+    # Our user has just typed in wtfuzz.py with known functioning url and the test_mylist.txt file as arguments.
+    wtfuzz.Fuzzer(['www.good-example.com', get_path('test_mylist.txt')]).run()
+
+    # They expect to see a "200" response for every attribute
+    expected_out = "Prepending protocol: http://www.good-example.com\n" \
+                   "200 : http://www.good-example.com/index.html\n" \
+                   "200 : http://www.good-example.com/home/careers.html\n"
+    out, err = capsys.readouterr()
+    assert out == expected_out
+
+    # However they don't trust our script yet so they run a test against a url
+    # they know wont respond to the home/careers.html resource in our list
+    wtfuzz.Fuzzer(['www.bad-example.com', get_path('test_mylist.txt')]).run()
+    expected_out = "Prepending protocol: http://www.bad-example.com\n" \
+                   "200 : http://www.bad-example.com/index.html\n" \
+                   "404 : http://www.bad-example.com/home/careers.html\n"
+    out, err = capsys.readouterr()
+    assert out == expected_out
+
+    # Finally they run the test against a url that doesn't exist.
+    wtfuzz.Fuzzer(['http://www.idontexist.com', get_path('test_mylist.txt')]).run()
+    expected_out = "Web server does not exist or is unavailable\n" \
+                   "Web server does not exist or is unavailable\n"
+    out, err = capsys.readouterr()
+    assert out == expected_out

--- a/wtfuzz/wtfuzz.py
+++ b/wtfuzz/wtfuzz.py
@@ -1,32 +1,42 @@
-
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
-import os
 import time
-
+import sys
 import crayons
 import requests
 
+
 class Fuzzer(object):
-    def __init__(self):
-        parser = argparse.ArgumentParser(description='A CLI tool for finding web resources')
-        parser.add_argument('-w', metavar='wait_time', required=False, type=int, default=0, help='an optional time to wait between the number of requests given by the -n flag. Note: this is per thread.')
-        parser.add_argument('-n', metavar='num_requests', required=False, type=int, default=0, help='an optional number of requests to make before waiting for the time specified by the -w flag. Note: this is per thread.')
-        parser.add_argument('-t', metavar='num_threads', required=False, type=int, default=1, help='an optional number of threads to use to send requests.')
-        parser.add_argument('-o', metavar='output_file', required=False, type=str, help='an optional file to log output to.')
-        parser.add_argument('-m', metavar='http_method', required=False, type=str, default='GET', help='http method to use for requests')
-        parser.add_argument('-c', metavar=('http_status', 'color'), required=False, action='append', nargs=2, help='customize what color a given http status code will display as. Note: this parameter can be specified multiple times. Available Colors: [red,green,yellow,blue,black,magenta,cyan,white]')
-        parser.add_argument('-b', metavar='http_body', required=False, type=str, help='http body to use for requests')
-        parser.add_argument('--only', metavar='http_status', required=False, type=int, help='only show requests that return http_status')
-        parser.add_argument('root_url', help='the url you want to start the search from')
-        parser.add_argument('list_file', type=str, help='an optional list of resources to check')
-        self.args = parser.parse_args()
+    def __init__(self, args=None):
+
+        self.args = self._check_args(args)
 
         self.color_override = self._build_color_override_map(self.args.c)
         self.root_url = self._generate_root_url(self.args.root_url)
 
         self._load_tests()
         self._open_file()
+
+    def _check_args(self, args=None):
+        parser = argparse.ArgumentParser(description='A CLI tool for finding web resources')
+        parser.add_argument('-w', metavar='wait_time', required=False, type=int, default=0,
+                            help='an optional time to wait between the number of requests given by the -n flag. Note: this is per thread.')
+        parser.add_argument('-n', metavar='num_requests', required=False, type=int, default=0,
+                            help='an optional number of requests to make before waiting for the time specified by the -w flag. Note: this is per thread.')
+        parser.add_argument('-t', metavar='num_threads', required=False, type=int, default=1,
+                            help='an optional number of threads to use to send requests.')
+        parser.add_argument('-o', metavar='output_file', required=False, type=str,
+                            help='an optional file to log output to.')
+        parser.add_argument('-m', metavar='http_method', required=False, type=str, default='GET',
+                            help='http method to use for requests')
+        parser.add_argument('-c', metavar=('http_status', 'color'), required=False, action='append', nargs=2,
+                            help='customize what color a given http status code will display as. Note: this parameter can be specified multiple times. Available Colors: [red,green,yellow,blue,black,magenta,cyan,white]')
+        parser.add_argument('-b', metavar='http_body', required=False, type=str, help='http body to use for requests')
+        parser.add_argument('--only', metavar='http_status', required=False, type=int,
+                            help='only show requests that return http_status')
+        parser.add_argument('root_url', help='the url you want to start the search from')
+        parser.add_argument('list_file', type=str, help='an optional list of resources to check')
+        return parser.parse_args(args)
 
     def run(self):
         num_threads = self.args.t if self.args.t >= 1 else 1
@@ -40,7 +50,7 @@ class Fuzzer(object):
 
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
             futures = []
-            
+
             for key, bucket in test_buckets.items():
                 future = executor.submit(self.send_requests, bucket)
                 futures.append(future)
@@ -51,7 +61,7 @@ class Fuzzer(object):
     def send_requests(self, bucket):
         num_requests = 0
         for test in bucket:
-            
+
             if self.args.n > 0 and num_requests == self.args.n:
                 num_requests = 0
                 time.sleep(self.args.w)
@@ -116,7 +126,6 @@ class Fuzzer(object):
             return requests.put(url, data=body)
         raise ValueError('Invalid argument, http_method: {}'.format(method))
 
-
     def _load_tests(self):
         self.tests = []
 
@@ -142,8 +151,11 @@ class Fuzzer(object):
             self.outfile.write('{}\n'.format(string))
         print(string)
 
+
 def main():
-    wtfuzz = Fuzzer()
+    wtfuzz = Fuzzer(sys.argv[1:])
     wtfuzz.run()
 
-if __name__ == '__main__': main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is an initial py.test functional test. Mocking out requests with responses
In order to allow for testing needed to refactor the way the class processes arguments so that the arguments can be directly passed via a call to the class instead of parsing sysargs by default.

A separate function wasn't completely necessary but this allows clarity for where the arguments when invoking your class are.

Edit:
Fixes #2 